### PR TITLE
Fix duplicate seat order bug

### DIFF
--- a/src/Actions/index.js
+++ b/src/Actions/index.js
@@ -142,3 +142,9 @@ export const removeCurrentSeat = (currentSeat) => {
     currentSeat
   };
 };
+
+export const removeCurrentTable = () => {
+  return {
+    type: 'REMOVE_CURRENT_TABLE'
+  };
+};

--- a/src/Actions/index.js
+++ b/src/Actions/index.js
@@ -135,3 +135,10 @@ export const addOrderToCurrentSeat = (order) => {
     order
   };
 };
+
+export const removeCurrentSeat = (currentSeat) => {
+  return {
+    type: 'REMOVE_CURRENT_SEAT',
+    currentSeat
+  };
+};

--- a/src/Components/App/__snapshots__/App.test.js.snap
+++ b/src/Components/App/__snapshots__/App.test.js.snap
@@ -40,9 +40,9 @@ ShallowWrapper {
                 render={[Function]}
         />
         <Route
+                component={[Function]}
                 exact={true}
                 path="/:loginCode/tables/:table"
-                render={[Function]}
         />
         <Route
                 component={[Function]}
@@ -88,9 +88,9 @@ ShallowWrapper {
             render={[Function]}
 />,
           <Route
+            component={[Function]}
             exact={true}
             path="/:loginCode/tables/:table"
-            render={[Function]}
 />,
           <Route
             component={[Function]}
@@ -168,9 +168,9 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "class",
           "props": Object {
+            "component": [Function],
             "exact": true,
             "path": "/:loginCode/tables/:table",
-            "render": [Function],
           },
           "ref": null,
           "rendered": null,
@@ -249,9 +249,9 @@ ShallowWrapper {
                     render={[Function]}
           />
           <Route
+                    component={[Function]}
                     exact={true}
                     path="/:loginCode/tables/:table"
-                    render={[Function]}
           />
           <Route
                     component={[Function]}
@@ -297,9 +297,9 @@ ShallowWrapper {
               render={[Function]}
 />,
             <Route
+              component={[Function]}
               exact={true}
               path="/:loginCode/tables/:table"
-              render={[Function]}
 />,
             <Route
               component={[Function]}
@@ -377,9 +377,9 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "class",
             "props": Object {
+              "component": [Function],
               "exact": true,
               "path": "/:loginCode/tables/:table",
-              "render": [Function],
             },
             "ref": null,
             "rendered": null,

--- a/src/Components/Entree/Entree.js
+++ b/src/Components/Entree/Entree.js
@@ -15,17 +15,15 @@ class Entree extends Component {
   }
 
   removeFromOrder(menuItem) {
-    console.log('menuItem to remove: ', menuItem);
     this.props.removeFromCurrentSeatOrder(menuItem);
   }
 
   addOrderToSeat() {
-    //add to currentSeat in store
-    console.log('currentSeatOrder: ', this.props.currentSeatOrder);
     this.props.addOrderToCurrentSeat(this.props.currentSeatOrder);
     this.props.addToCurrentTableOrder(this.props.currentSeatOrder,
       this.props.currentSeat.seatNumber);
     this.props.clearCurrentSeatOrder();
+    this.props.removeCurrentSeat(this.props.currentSeat);
   }
 
   displaycurrentSeatOrder() {
@@ -81,7 +79,8 @@ Entree.propTypes = {
   removeFromCurrentSeatOrder: PropTypes.func,
   currentUser: PropTypes.object,
   addToCurrentTableOrder: PropTypes.func,
-  addOrderToCurrentSeat: PropTypes.func
+  addOrderToCurrentSeat: PropTypes.func,
+  removeCurrentSeat: PropTypes.func
 };
 
 export default Entree;

--- a/src/Components/Entree/Entree.js
+++ b/src/Components/Entree/Entree.js
@@ -15,11 +15,13 @@ class Entree extends Component {
   }
 
   removeFromOrder(menuItem) {
+    console.log('menuItem to remove: ', menuItem);
     this.props.removeFromCurrentSeatOrder(menuItem);
   }
 
   addOrderToSeat() {
     //add to currentSeat in store
+    console.log('currentSeatOrder: ', this.props.currentSeatOrder);
     this.props.addOrderToCurrentSeat(this.props.currentSeatOrder);
     this.props.addToCurrentTableOrder(this.props.currentSeatOrder,
       this.props.currentSeat.seatNumber);

--- a/src/Components/Entree/__snapshots__/Entree.test.js.snap
+++ b/src/Components/Entree/__snapshots__/Entree.test.js.snap
@@ -159,7 +159,9 @@ ShallowWrapper {
           className="current-order"
 >
           Current Order:
-          <li>
+          <li
+                    className="item-added-to-seat"
+          >
                     Lamb
                     <button
                               className="edit-order-item-button"
@@ -167,13 +169,15 @@ ShallowWrapper {
                               Edit
                     </button>
                     <button
-                              className="remove-order-item-button"
+                              className="remove-entree-order-item-button"
                               onClick={[Function]}
                     >
-                              Remove
+                              X
                     </button>
           </li>
-          <li>
+          <li
+                    className="item-added-to-seat"
+          >
                     Burger
                     <button
                               className="edit-order-item-button"
@@ -181,13 +185,15 @@ ShallowWrapper {
                               Edit
                     </button>
                     <button
-                              className="remove-order-item-button"
+                              className="remove-entree-order-item-button"
                               onClick={[Function]}
                     >
-                              Remove
+                              X
                     </button>
           </li>
-          <li>
+          <li
+                    className="item-added-to-seat"
+          >
                     Mahi Mahi
                     <button
                               className="edit-order-item-button"
@@ -195,10 +201,10 @@ ShallowWrapper {
                               Edit
                     </button>
                     <button
-                              className="remove-order-item-button"
+                              className="remove-entree-order-item-button"
                               onClick={[Function]}
                     >
-                              Remove
+                              X
                     </button>
           </li>
 </ul>,
@@ -485,7 +491,9 @@ ShallowWrapper {
           "children": Array [
             "Current Order:",
             Array [
-              <li>
+              <li
+                className="item-added-to-seat"
+>
                 Lamb
                 <button
                                 className="edit-order-item-button"
@@ -493,13 +501,15 @@ ShallowWrapper {
                                 Edit
                 </button>
                 <button
-                                className="remove-order-item-button"
+                                className="remove-entree-order-item-button"
                                 onClick={[Function]}
                 >
-                                Remove
+                                X
                 </button>
 </li>,
-              <li>
+              <li
+                className="item-added-to-seat"
+>
                 Burger
                 <button
                                 className="edit-order-item-button"
@@ -507,13 +517,15 @@ ShallowWrapper {
                                 Edit
                 </button>
                 <button
-                                className="remove-order-item-button"
+                                className="remove-entree-order-item-button"
                                 onClick={[Function]}
                 >
-                                Remove
+                                X
                 </button>
 </li>,
-              <li>
+              <li
+                className="item-added-to-seat"
+>
                 Mahi Mahi
                 <button
                                 className="edit-order-item-button"
@@ -521,10 +533,10 @@ ShallowWrapper {
                                 Edit
                 </button>
                 <button
-                                className="remove-order-item-button"
+                                className="remove-entree-order-item-button"
                                 onClick={[Function]}
                 >
-                                Remove
+                                X
                 </button>
 </li>,
             ],
@@ -547,12 +559,13 @@ ShallowWrapper {
                   Edit
 </button>,
                 <button
-                  className="remove-order-item-button"
+                  className="remove-entree-order-item-button"
                   onClick={[Function]}
 >
-                  Remove
+                  X
 </button>,
               ],
+              "className": "item-added-to-seat",
             },
             "ref": null,
             "rendered": Array [
@@ -574,12 +587,12 @@ ShallowWrapper {
                 "key": undefined,
                 "nodeType": "host",
                 "props": Object {
-                  "children": "Remove",
-                  "className": "remove-order-item-button",
+                  "children": "X",
+                  "className": "remove-entree-order-item-button",
                   "onClick": [Function],
                 },
                 "ref": null,
-                "rendered": "Remove",
+                "rendered": "X",
                 "type": "button",
               },
             ],
@@ -598,12 +611,13 @@ ShallowWrapper {
                   Edit
 </button>,
                 <button
-                  className="remove-order-item-button"
+                  className="remove-entree-order-item-button"
                   onClick={[Function]}
 >
-                  Remove
+                  X
 </button>,
               ],
+              "className": "item-added-to-seat",
             },
             "ref": null,
             "rendered": Array [
@@ -625,12 +639,12 @@ ShallowWrapper {
                 "key": undefined,
                 "nodeType": "host",
                 "props": Object {
-                  "children": "Remove",
-                  "className": "remove-order-item-button",
+                  "children": "X",
+                  "className": "remove-entree-order-item-button",
                   "onClick": [Function],
                 },
                 "ref": null,
-                "rendered": "Remove",
+                "rendered": "X",
                 "type": "button",
               },
             ],
@@ -649,12 +663,13 @@ ShallowWrapper {
                   Edit
 </button>,
                 <button
-                  className="remove-order-item-button"
+                  className="remove-entree-order-item-button"
                   onClick={[Function]}
 >
-                  Remove
+                  X
 </button>,
               ],
+              "className": "item-added-to-seat",
             },
             "ref": null,
             "rendered": Array [
@@ -676,12 +691,12 @@ ShallowWrapper {
                 "key": undefined,
                 "nodeType": "host",
                 "props": Object {
-                  "children": "Remove",
-                  "className": "remove-order-item-button",
+                  "children": "X",
+                  "className": "remove-entree-order-item-button",
                   "onClick": [Function],
                 },
                 "ref": null,
-                "rendered": "Remove",
+                "rendered": "X",
                 "type": "button",
               },
             ],
@@ -797,7 +812,9 @@ ShallowWrapper {
             className="current-order"
 >
             Current Order:
-            <li>
+            <li
+                        className="item-added-to-seat"
+            >
                         Lamb
                         <button
                                     className="edit-order-item-button"
@@ -805,13 +822,15 @@ ShallowWrapper {
                                     Edit
                         </button>
                         <button
-                                    className="remove-order-item-button"
+                                    className="remove-entree-order-item-button"
                                     onClick={[Function]}
                         >
-                                    Remove
+                                    X
                         </button>
             </li>
-            <li>
+            <li
+                        className="item-added-to-seat"
+            >
                         Burger
                         <button
                                     className="edit-order-item-button"
@@ -819,13 +838,15 @@ ShallowWrapper {
                                     Edit
                         </button>
                         <button
-                                    className="remove-order-item-button"
+                                    className="remove-entree-order-item-button"
                                     onClick={[Function]}
                         >
-                                    Remove
+                                    X
                         </button>
             </li>
-            <li>
+            <li
+                        className="item-added-to-seat"
+            >
                         Mahi Mahi
                         <button
                                     className="edit-order-item-button"
@@ -833,10 +854,10 @@ ShallowWrapper {
                                     Edit
                         </button>
                         <button
-                                    className="remove-order-item-button"
+                                    className="remove-entree-order-item-button"
                                     onClick={[Function]}
                         >
-                                    Remove
+                                    X
                         </button>
             </li>
 </ul>,
@@ -1123,7 +1144,9 @@ ShallowWrapper {
             "children": Array [
               "Current Order:",
               Array [
-                <li>
+                <li
+                  className="item-added-to-seat"
+>
                   Lamb
                   <button
                                     className="edit-order-item-button"
@@ -1131,13 +1154,15 @@ ShallowWrapper {
                                     Edit
                   </button>
                   <button
-                                    className="remove-order-item-button"
+                                    className="remove-entree-order-item-button"
                                     onClick={[Function]}
                   >
-                                    Remove
+                                    X
                   </button>
 </li>,
-                <li>
+                <li
+                  className="item-added-to-seat"
+>
                   Burger
                   <button
                                     className="edit-order-item-button"
@@ -1145,13 +1170,15 @@ ShallowWrapper {
                                     Edit
                   </button>
                   <button
-                                    className="remove-order-item-button"
+                                    className="remove-entree-order-item-button"
                                     onClick={[Function]}
                   >
-                                    Remove
+                                    X
                   </button>
 </li>,
-                <li>
+                <li
+                  className="item-added-to-seat"
+>
                   Mahi Mahi
                   <button
                                     className="edit-order-item-button"
@@ -1159,10 +1186,10 @@ ShallowWrapper {
                                     Edit
                   </button>
                   <button
-                                    className="remove-order-item-button"
+                                    className="remove-entree-order-item-button"
                                     onClick={[Function]}
                   >
-                                    Remove
+                                    X
                   </button>
 </li>,
               ],
@@ -1185,12 +1212,13 @@ ShallowWrapper {
                     Edit
 </button>,
                   <button
-                    className="remove-order-item-button"
+                    className="remove-entree-order-item-button"
                     onClick={[Function]}
 >
-                    Remove
+                    X
 </button>,
                 ],
+                "className": "item-added-to-seat",
               },
               "ref": null,
               "rendered": Array [
@@ -1212,12 +1240,12 @@ ShallowWrapper {
                   "key": undefined,
                   "nodeType": "host",
                   "props": Object {
-                    "children": "Remove",
-                    "className": "remove-order-item-button",
+                    "children": "X",
+                    "className": "remove-entree-order-item-button",
                     "onClick": [Function],
                   },
                   "ref": null,
-                  "rendered": "Remove",
+                  "rendered": "X",
                   "type": "button",
                 },
               ],
@@ -1236,12 +1264,13 @@ ShallowWrapper {
                     Edit
 </button>,
                   <button
-                    className="remove-order-item-button"
+                    className="remove-entree-order-item-button"
                     onClick={[Function]}
 >
-                    Remove
+                    X
 </button>,
                 ],
+                "className": "item-added-to-seat",
               },
               "ref": null,
               "rendered": Array [
@@ -1263,12 +1292,12 @@ ShallowWrapper {
                   "key": undefined,
                   "nodeType": "host",
                   "props": Object {
-                    "children": "Remove",
-                    "className": "remove-order-item-button",
+                    "children": "X",
+                    "className": "remove-entree-order-item-button",
                     "onClick": [Function],
                   },
                   "ref": null,
-                  "rendered": "Remove",
+                  "rendered": "X",
                   "type": "button",
                 },
               ],
@@ -1287,12 +1316,13 @@ ShallowWrapper {
                     Edit
 </button>,
                   <button
-                    className="remove-order-item-button"
+                    className="remove-entree-order-item-button"
                     onClick={[Function]}
 >
-                    Remove
+                    X
 </button>,
                 ],
+                "className": "item-added-to-seat",
               },
               "ref": null,
               "rendered": Array [
@@ -1314,12 +1344,12 @@ ShallowWrapper {
                   "key": undefined,
                   "nodeType": "host",
                   "props": Object {
-                    "children": "Remove",
-                    "className": "remove-order-item-button",
+                    "children": "X",
+                    "className": "remove-entree-order-item-button",
                     "onClick": [Function],
                   },
                   "ref": null,
-                  "rendered": "Remove",
+                  "rendered": "X",
                   "type": "button",
                 },
               ],

--- a/src/Components/SeatManager/SeatManager.css
+++ b/src/Components/SeatManager/SeatManager.css
@@ -75,7 +75,8 @@
   border-radius: 25px;
   color: #33202A;
   position: relative;
-  margin-top: 5px; }
+  margin-top: 5px;
+  border: none; }
 
 .server-dashboard-wrapper {
   height: 79%; }

--- a/src/Components/SeatManager/SeatManager.js
+++ b/src/Components/SeatManager/SeatManager.js
@@ -91,7 +91,8 @@ class SeatManager extends Component {
             </div>
 
             <button className='send-order-button'
-              onClick={() => this.sendOrder()}>Send Order</button>
+              onClick={() => this.sendOrder()}
+              disabled={this.props.currentTableOrder.length <= 0}>Send Order</button>
             <Link to={`/${this.props.currentUser.loginCode}/tables`}>
               <button className='close-table-button'
                 onClick={() => this.closeTable()}>Close Table</button>

--- a/src/Components/SeatManager/SeatManager.js
+++ b/src/Components/SeatManager/SeatManager.js
@@ -79,8 +79,10 @@ class SeatManager extends Component {
                 onClick={(event) => this.handleSubmit(event)}>Add Seat</button>
             </form>
             <Link to={`/${this.props.currentUser.loginCode}/tables`}>
-              <h3 className='all-tables-button'
-              >All Tables</h3>
+              <button className='all-tables-button'
+                disabled={this.props.currentTableOrder.length > 0}
+              >All Tables
+              </button>
             </Link>
             <h3 className='table-info-seat-manager'>
               Table {this.props.currentTable.tableNumber}</h3>

--- a/src/Components/SeatManager/SeatManager.js
+++ b/src/Components/SeatManager/SeatManager.js
@@ -79,7 +79,8 @@ class SeatManager extends Component {
                 onClick={(event) => this.handleSubmit(event)}>Add Seat</button>
             </form>
             <Link to={`/${this.props.currentUser.loginCode}/tables`}>
-              <h3 className='all-tables-button'>All Tables</h3>
+              <h3 className='all-tables-button'
+              >All Tables</h3>
             </Link>
             <h3 className='table-info-seat-manager'>
               Table {this.props.currentTable.tableNumber}</h3>
@@ -114,7 +115,8 @@ SeatManager.propTypes = {
   addToAllOrders: PropTypes.func,
   clearCurrentTableOrder: PropTypes.func,
   addMenuItem: PropTypes.func,
-  removeTable: PropTypes.func
+  removeTable: PropTypes.func,
+  removeCurrentTable: PropTypes.func
 };
 
 export default SeatManager;

--- a/src/Components/SeatManager/SeatManager.scss
+++ b/src/Components/SeatManager/SeatManager.scss
@@ -48,6 +48,15 @@
   margin-bottom: 10px;
   margin-top: 10px;
   font-size: 16px;
+  border: none;
+}
+
+.all-tables-button:disabled {
+  background-color: #AEAEAF;
+}
+
+.send-order-button:disabled {
+  background-color: #AEAEAF;
 }
 
 .add-seat {
@@ -84,7 +93,6 @@
   color: #33202A;
   position: relative;
   margin-top: 5px;
-
 }
 
 .server-dashboard-wrapper {

--- a/src/Components/TableManager/TableManager.js
+++ b/src/Components/TableManager/TableManager.js
@@ -13,6 +13,10 @@ class TableManager extends Component {
     };
   }
 
+  componentDidMount() {
+    this.props.removeCurrentTable();
+  }
+
   updateState(event) {
     this.setState({
       input: event.target.value
@@ -86,7 +90,8 @@ TableManager.propTypes = {
   addTable: PropTypes.func,
   tables: PropTypes.array,
   addCurrentTable: PropTypes.func,
-  currentTable: PropTypes.object
+  currentTable: PropTypes.object,
+  removeCurrentTable: PropTypes.func
 };
 
 export default TableManager;

--- a/src/Containers/EntreeContainer.js
+++ b/src/Containers/EntreeContainer.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import Entree from './../Components/Entree/Entree';
-import { addToCurrentSeatOrder, clearCurrentSeatOrder, removeFromCurrentSeatOrder, addToCurrentTableOrder, addOrderToCurrentSeat } from './../Actions/index';
+import { addToCurrentSeatOrder, clearCurrentSeatOrder, removeFromCurrentSeatOrder, addToCurrentTableOrder, addOrderToCurrentSeat, removeCurrentSeat } from './../Actions/index';
 
 const mapStateToProps = (store) => ({
   currentUser: store.currentUser,
@@ -25,6 +25,9 @@ const mapDispatchToProps = (dispatch) => ({
   },
   addOrderToCurrentSeat: (order) => {
     return dispatch(addOrderToCurrentSeat(order));
+  },
+  removeCurrentSeat: (currentSeat) => {
+    return dispatch(removeCurrentSeat(currentSeat));
   }
 });
 

--- a/src/Containers/EntreeContainer.js
+++ b/src/Containers/EntreeContainer.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import Entree from './../Components/Entree/Entree';
-import { addToCurrentSeatOrder, clearCurrentSeatOrder, removeFromCurrentSeatOrder, addToCurrentTableOrder, addOrderToCurrentSeat, removeCurrentSeat } from './../Actions/index';
+import { addToCurrentSeatOrder, clearCurrentSeatOrder, removeFromCurrentSeatOrder, addToCurrentTableOrder, addOrderToCurrentSeat, removeCurrentSeat, removeCurrentTable } from './../Actions/index';
 
 const mapStateToProps = (store) => ({
   currentUser: store.currentUser,
@@ -28,6 +28,9 @@ const mapDispatchToProps = (dispatch) => ({
   },
   removeCurrentSeat: (currentSeat) => {
     return dispatch(removeCurrentSeat(currentSeat));
+  },
+  removeCurrentTable: (currentTable) => {
+    return dispatch(removeCurrentTable(currentTable));
   }
 });
 

--- a/src/Containers/SeatManagerContainer.js
+++ b/src/Containers/SeatManagerContainer.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { addSeat, addCurrentSeat, addToAllOrders, clearCurrentTableOrder, addMenuItem, removeTable } from './../Actions/index.js';
+import { addSeat, addCurrentSeat, addToAllOrders, clearCurrentTableOrder, addMenuItem, removeTable, removeCurrentTable } from './../Actions/index.js';
 import SeatManager from './../Components/SeatManager/SeatManager';
 
 const mapStateToProps = (store) => ({
@@ -28,6 +28,9 @@ const mapDispatchToProps = (dispatch) => ({
   },
   removeTable: (indexToRemove) => {
     return dispatch(removeTable(indexToRemove));
+  },
+  removeCurrentTable: (currentTable) => {
+    return dispatch(removeCurrentTable(currentTable));
   }
 });
 

--- a/src/Containers/TableManagerContainer.js
+++ b/src/Containers/TableManagerContainer.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { addTable, addCurrentTable } from './../Actions/index.js';
+import { addTable, addCurrentTable, removeCurrentTable } from './../Actions/index.js';
 import TableManager from './../Components/TableManager/TableManager';
 
 const mapStateToProps = (store) => ({
@@ -14,6 +14,9 @@ const mapDispatchToProps = (dispatch) => ({
   },
   addCurrentTable: (table) => {
     return dispatch(addCurrentTable(table));
+  },
+  removeCurrentTable: (currentTable) => {
+    return dispatch(removeCurrentTable(currentTable));
   }
 });
 

--- a/src/Reducers/Reducers.test.js
+++ b/src/Reducers/Reducers.test.js
@@ -2,6 +2,9 @@ import tables from './AddTableReducer';
 import allOrders from './AllOrdersReducer';
 import currentSeatOrder from './CurrentSeatOrderReducer';
 import currentSeat from './CurrentSeatReducer';
+import currentTableOrder from './CurrentTableOrderReducer';
+import currentTable from './CurrentTableReducer';
+import currentUser from './LoginReducer';
 
 describe(`reducers tests`, () => {
   it(`tables: should return tables' initial state and should
@@ -93,7 +96,7 @@ describe(`reducers tests`, () => {
     seats: [{seatNumber: '1', tableNumber: '22', order: []}]
   }], removeTableAction)).toEqual([]);
 
-  it(`orders: it should return default state and
+  it(`all orders: it should return default state and
     allow to add, remove ,and clear orders`, () => {
 
       expect(tables(undefined, '')).toEqual([]);
@@ -143,33 +146,35 @@ describe(`reducers tests`, () => {
         ]
       }]);
 
-      // const removeFromAllOrdersAction = {
-      //   type: 'REMOVE_FROM_ALL_ORDERS',
-      //   order: {
-      //     currentTableOrder: [
-      //       {
-      //         seatNumber: '2',
-      //         currentSeatOrder: [
-      //           {item: 'Scallops', price: 30}
-      //         ]
-      //       }
-      //     ],
-      //     server: "Jen",
-      //     tableNumber: "22"
-      //   }
-      // };
-      // expect(allOrders([{
-      //   currentTableOrder: [
-      //     {
-      //       seatNumber: '2',
-      //       currentSeatOrder: [
-      //         {item: 'Scallops', price: 30}
-      //       ]
-      //     }
-      //   ],
-      //   server: "Jen",
-      //   tableNumber: "22"
-      // }], removeFromAllOrdersAction)).toEqual([]);
+      const removeFromAllOrdersAction = {
+        type: 'REMOVE_FROM_ALL_ORDERS',
+        order: {
+          currentTableOrder: [
+            {
+              seatNumber: '2',
+              currentSeatOrder: [
+                {item: 'Scallops', price: 30}
+              ]
+            }
+          ],
+          server: "Jen",
+          tableNumber: "22"
+        }
+      };
+
+      // this test fails
+      expect(allOrders([{
+        currentTableOrder: [
+          {
+            seatNumber: '2',
+            currentSeatOrder: [
+              {item: 'Scallops', price: 30}
+            ]
+          }
+        ],
+        server: "Jen",
+        tableNumber: "22"
+      }], removeFromAllOrdersAction)).toEqual([]);
 
     });
 
@@ -193,18 +198,19 @@ describe(`reducers tests`, () => {
         price: 29
       }]);
 
-      // const removeFromCurrentSeatAction = {
-      //   type: 'REMOVE_FROM_CURRENT_SEAT_ORDER',
-      //   menuItem: {
-      //     item: 'Lamb',
-      //     price: 29
-      //   }
-      // };
+      const removeFromCurrentSeatAction = {
+        type: 'REMOVE_FROM_CURRENT_SEAT_ORDER',
+        menuItem: {
+          item: 'Lamb',
+          price: 29
+        }
+      };
 
-      // expect(currentSeatOrder([{
-      //   item: 'Lamb',
-      //   price: 29
-      // }], removeFromCurrentSeatAction)).toEqual([]);
+      // this test fails
+      expect(currentSeatOrder([{
+        item: 'Lamb',
+        price: 29
+      }], removeFromCurrentSeatAction)).toEqual([]);
 
       const clearCurrentSeatOrderAction = {
         type: 'CLEAR_CURRENT_SEAT_ORDER'
@@ -241,29 +247,142 @@ describe(`reducers tests`, () => {
         order: []
       });
 
-      // const addOrderToCurrentSeatAction = {
-      //   type: 'ADD_CURRENT_SEAT',
-      //   seatInfo: {
-      //     seatNumber: '1',
-      //     tableNumber: '22',
-      //     order: [
-      //       {item: 'Lamb', price: 29},
-      //       {item: 'Burger', price: 19},
-      //       {item:'Mahi Mahi', price: 27}
-      //     ]
-      //   }
-      // };
-      //
-      // expect(currentSeat({}, addOrderToCurrentSeatAction)).toEqual({
-      //   seatNumber: '1',
-      //   tableNumber: '22',
-      //   order: [
-      //     {item: 'Lamb', price: 29},
-      //     {item: 'Burger', price: 19},
-      //     {item:'Mahi Mahi', price: 27}
-      //   ]
-      // });
+      const addOrderToCurrentSeatAction = {
+        type: 'ADD_ORDER_TO_CURRENT_SEAT',
+        order: [
+          {item: 'Lamb', price: 29},
+          {item: 'Burger', price: 19},
+          {item:'Mahi Mahi', price: 27}
+        ]
+
+      };
+
+      expect(currentSeat({
+        seatNumber: '1',
+        tableNumber: '22',
+        order: []
+      }, addOrderToCurrentSeatAction)).toEqual({
+        seatNumber: '1',
+        tableNumber: '22',
+        order: [
+          {item: 'Lamb', price: 29},
+          {item: 'Burger', price: 19},
+          {item:'Mahi Mahi', price: 27}
+        ]
+      });
 
     });
 
+  it(`current table order: it should return default state and
+        allow to remove current seat and add orders to seat`, () => {
+
+      expect(currentTableOrder(undefined, '')).toEqual([]);
+
+      const addToCurrentTableOrderAction =
+             {
+               type: 'ADD_TO_CURRENT_TABLE_ORDER',
+               addToTableInfo: {
+                 currentSeatOrder: [
+                   {item: 'Lamb', price: 29},
+                   {item: 'Burger', price: 19},
+                   {item:'Mahi Mahi', price: 27}
+                 ],
+                 seatNumber: '2'
+               }
+             };
+
+      expect(currentTableOrder([], addToCurrentTableOrderAction)).toEqual([{
+        seatNumber: '2',
+        currentSeatOrder:[
+          {item: 'Lamb', price: 29},
+          {item: 'Burger', price: 19},
+          {item:'Mahi Mahi', price: 27}]
+      }]);
+
+      const removeFromCurrentTableOrderAction =
+        {
+          type: 'REMOVE_FROM_CURRENT_TABLE_ORDER',
+          removeItemInfo: {
+            menuItem: {item: 'Lamb', price: 29},
+            seatNumber: '2'
+          }
+        };
+
+      // this test fails
+      expect(currentTableOrder([{
+        seatNumber: '2',
+        currentSeatOrder:[
+          {item: 'Lamb', price: 29},
+          {item: 'Burger', price: 19},
+          {item:'Mahi Mahi', price: 27}]
+      }], removeFromCurrentTableOrderAction)).toEqual([]);
+
+      const clearCurrentTableOrderAction =
+        {
+          type: 'CLEAR_CURRENT_TABLE_ORDER'
+        };
+
+      expect(currentTableOrder([{
+        seatNumber: '2',
+        currentSeatOrder:[
+          {item: 'Lamb', price: 29},
+          {item: 'Burger', price: 19},
+          {item:'Mahi Mahi', price: 27}]
+      }], clearCurrentTableOrderAction)).toEqual([]);
+    });
+
+
+  it(`current table: it should return default state and
+        allow to add a current table and remove a current table`, () => {
+      expect(currentTable(undefined, '')).toEqual({});
+
+      const addTableAction = {
+        type: 'ADD_CURRENT_TABLE',
+        currentTable: {
+          tableNumber: '33',
+          seats: {}
+        }
+      };
+
+      expect(currentTable({}, addTableAction)).toEqual({
+        tableNumber: '33',
+        seats: {}
+      });
+
+    });
+
+  it(`login: it should return default state and
+              allow user to log in and log out`, () => {
+
+      expect(currentUser(undefined, '')).toEqual({});
+
+      const loginUserAction = {
+        type: 'LOGIN_USER',
+        currentUser: {
+          name: 'Jen',
+          loginCode: '0000'
+        }
+      };
+
+      expect(currentUser({}, loginUserAction)).toEqual({
+        name: 'Jen',
+        loginCode: '0000'
+      });
+
+      const logoutUserAction = {
+        type: 'LOGOUT_USER',
+        currentUser: {
+          name: 'Jen',
+          loginCode: '0000'
+        }
+      };
+
+      expect(currentUser({
+        name: 'Jen',
+        loginCode: '0000'
+      }, logoutUserAction)).toEqual({});
+
+
+
+    });
 });


### PR DESCRIPTION
## What's this PR do?

Removes ability to go to other tables when an order has not been sent. Resolves bug in https://github.com/jenPlusPlus/eighty-six-systems/issues/51

## Pre-Merge TODOs
 - [x] Screenshots Included
    The All Tables and Send Order buttons toggle their availability on/off with styles to match the state.
<img width="794" alt="screen shot 2017-11-08 at 12 35 13 pm" src="https://user-images.githubusercontent.com/6845268/32570506-858ae562-c481-11e7-87cd-a4963958075f.png">
<img width="802" alt="screen shot 2017-11-08 at 12 35 27 pm" src="https://user-images.githubusercontent.com/6845268/32570507-85a1eb68-c481-11e7-9a67-27185a40cdfd.png">
<img width="797" alt="screen shot 2017-11-08 at 12 35 42 pm" src="https://user-images.githubusercontent.com/6845268/32570508-85b2750a-c481-11e7-9946-58d643b837df.png">
<img width="796" alt="screen shot 2017-11-08 at 12 35 54 pm" src="https://user-images.githubusercontent.com/6845268/32570509-85c3db4c-c481-11e7-87be-73353aa54063.png">

## Where should the reviewer start?
See changes in changed files.

## Any background context you want to provide?
See https://github.com/jenPlusPlus/eighty-six-systems/issues/51

## What gif best describes this PR or how it makes you feel?
![giphy 3](https://user-images.githubusercontent.com/6845268/32570604-e355eac0-c481-11e7-9a58-16c11f2a5247.gif)
