### PR TITLE
Persist order on seats

### DIFF
--- a/src/Actions/index.js
+++ b/src/Actions/index.js
@@ -117,7 +117,8 @@ export const addToAllOrders = (serverName, tableNumber, currentTableOrder) => {
     orderInfo: {
       server: serverName,
       tableNumber: tableNumber,
-      currentTableOrder: currentTableOrder
+      currentTableOrder: currentTableOrder,
+      id: Date.now()
     }
   };
 };

--- a/src/Components/Entree/Entree.css
+++ b/src/Components/Entree/Entree.css
@@ -1,17 +1,66 @@
 .order-wrapper {
-  height: 35%;
+  height: 87%;
   text-align: center; }
 
 .entrees-list {
-  padding: 5px; }
+  width: 60%;
+  padding: 5px;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  margin: auto; }
 
 .entree-item {
-  margin-bottom: 3px;
+  margin: 10px;
   background-color: #33202A;
-  height: 100px;
-  width: 100px;
+  height: 50px;
+  width: 80px;
   border-radius: 10px;
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
   justify-content: space-around; }
+
+.current-order-wrapper {
+  height: 43%;
+  width: 60%;
+  margin: auto;
+  background-color: #EFEFF0;
+  border-radius: 10px;
+  margin-top: 5px; }
+
+.current-order {
+  color: #33202A;
+  height: 100%;
+  padding: 5px;
+  overflow-y: scroll; }
+
+.item-added-to-seat {
+  color: #33202A;
+  width: 40%;
+  margin: auto;
+  margin-top: 5px;
+  padding-left: 5px; }
+
+.add-order-to-seat-button {
+  border: none;
+  font-size: 12px;
+  margin: 5px 0 5px 0;
+  width: 85px;
+  height: 30px;
+  border-radius: 15px;
+  background-color: #EFEFF0;
+  color: #6D576A; }
+
+.remove-entree-order-item-button {
+  background-color: #DADADB;
+  color: #A63D40;
+  border-radius: 50%;
+  border: 1px solid #C68385;
+  width: 15px;
+  height: 15px;
+  font-size: 13px;
+  margin: 0 5px 0 3px;
+  text-align: center;
+  padding-bottom: 3px; }

--- a/src/Components/Entree/Entree.css
+++ b/src/Components/Entree/Entree.css
@@ -6,4 +6,12 @@
   padding: 5px; }
 
 .entree-item {
-  margin-bottom: 3px; }
+  margin-bottom: 3px;
+  background-color: #33202A;
+  height: 100px;
+  width: 100px;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  justify-content: space-around; }

--- a/src/Components/Entree/Entree.js
+++ b/src/Components/Entree/Entree.js
@@ -10,7 +10,8 @@ class Entree extends Component {
 
   addToOrder(entree, entreeObject) {
     const order = Object.assign({}, {item: entree},
-      {price: entreeObject.price});
+      {price: entreeObject.price},
+      {id: Date.now()});
     this.props.addToCurrentSeatOrder(order);
   }
 

--- a/src/Components/Entree/Entree.js
+++ b/src/Components/Entree/Entree.js
@@ -58,9 +58,11 @@ class Entree extends Component {
             {mappedEntrees}
           </div>
         </div>
-        <ul className='current-order'>Current Order:
-          {this.displaycurrentSeatOrder()}
-        </ul>
+        <div className='current-order-wrapper'>
+          <ul className='current-order'>Current Order:
+            {this.displaycurrentSeatOrder()}
+          </ul>
+        </div>
         <Link to={`/${this.props.currentUser.loginCode}/tables/${this.props.currentTable.tableNumber}`}>
           <button className='add-order-to-seat-button'
             onClick={() => this.addOrderToSeat()}>Add to Seat</button>

--- a/src/Components/Entree/Entree.js
+++ b/src/Components/Entree/Entree.js
@@ -53,13 +53,14 @@ class Entree extends Component {
     return (
       <div className='order-wrapper'>
         <div className='entrees-wrapper'>
-          Entrees
+          <h3>Entrees</h3>
           <div className='entrees-list'>
             {mappedEntrees}
           </div>
         </div>
+        <h3>Current Order: </h3>
         <div className='current-order-wrapper'>
-          <ul className='current-order'>Current Order:
+          <ul className='current-order'>
             {this.displaycurrentSeatOrder()}
           </ul>
         </div>

--- a/src/Components/Entree/Entree.scss
+++ b/src/Components/Entree/Entree.scss
@@ -1,5 +1,5 @@
 .order-wrapper {
-  height: 100%;
+  height: 87%;
   text-align: center;
 }
 
@@ -27,4 +27,49 @@
 
 .current-order-wrapper {
   height: 43%;
+  width: 60%;
+  margin: auto;
+  background-color: #EFEFF0;
+  border-radius: 10px;
+  margin-top: 5px;
+}
+
+.current-order {
+  color: #33202A;
+  height: 100%;
+  padding: 5px;
+  overflow-y: scroll;
+}
+
+.item-added-to-seat {
+    color: #33202A;
+    width: 40%;
+    margin: auto;
+    margin-top: 5px;
+    padding-left: 5px;
+}
+
+.add-order-to-seat-button {
+  border: none;
+  font-size: 12px;
+  margin: 5px 0 5px 0;
+  width: 85px;
+  height: 30px;
+  border-radius: 15px;
+  background-color: #EFEFF0;
+  color: #6D576A;
+}
+
+.remove-entree-order-item-button {
+  background-color: #DADADB;
+  color: #A63D40;
+  // float: left;
+  border-radius: 50%;
+  border: 1px solid #C68385;
+  width: 15px;
+  height: 15px;
+  font-size: 13px;
+  margin: 0 5px 0 3px;
+  text-align: center;
+  padding-bottom: 3px;
 }

--- a/src/Components/Entree/Entree.scss
+++ b/src/Components/Entree/Entree.scss
@@ -1,12 +1,30 @@
 .order-wrapper {
-  height: 35%;
+  height: 100%;
   text-align: center;
 }
 
 .entrees-list {
+  width: 60%;
   padding: 5px;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  margin: auto;
 }
 
 .entree-item {
-  margin-bottom: 3px;
+  margin: 10px;
+  background-color: #33202A;
+  height: 50px;
+  width: 80px;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  justify-content: space-around;
+}
+
+.current-order-wrapper {
+  height: 43%;
 }

--- a/src/Components/Entree/__snapshots__/Entree.test.js.snap
+++ b/src/Components/Entree/__snapshots__/Entree.test.js.snap
@@ -95,7 +95,9 @@ ShallowWrapper {
         <div
           className="entrees-wrapper"
 >
-          Entrees
+          <h3>
+                    Entrees
+          </h3>
           <div
                     className="entrees-list"
           >
@@ -155,59 +157,65 @@ ShallowWrapper {
                     </div>
           </div>
 </div>,
-        <ul
-          className="current-order"
+        <h3>
+          Current Order: 
+</h3>,
+        <div
+          className="current-order-wrapper"
 >
-          Current Order:
-          <li
-                    className="item-added-to-seat"
+          <ul
+                    className="current-order"
           >
-                    Lamb
-                    <button
-                              className="edit-order-item-button"
+                    <li
+                              className="item-added-to-seat"
                     >
-                              Edit
-                    </button>
-                    <button
-                              className="remove-entree-order-item-button"
-                              onClick={[Function]}
+                              Lamb
+                              <button
+                                        className="edit-order-item-button"
+                              >
+                                        Edit
+                              </button>
+                              <button
+                                        className="remove-entree-order-item-button"
+                                        onClick={[Function]}
+                              >
+                                        X
+                              </button>
+                    </li>
+                    <li
+                              className="item-added-to-seat"
                     >
-                              X
-                    </button>
-          </li>
-          <li
-                    className="item-added-to-seat"
-          >
-                    Burger
-                    <button
-                              className="edit-order-item-button"
+                              Burger
+                              <button
+                                        className="edit-order-item-button"
+                              >
+                                        Edit
+                              </button>
+                              <button
+                                        className="remove-entree-order-item-button"
+                                        onClick={[Function]}
+                              >
+                                        X
+                              </button>
+                    </li>
+                    <li
+                              className="item-added-to-seat"
                     >
-                              Edit
-                    </button>
-                    <button
-                              className="remove-entree-order-item-button"
-                              onClick={[Function]}
-                    >
-                              X
-                    </button>
-          </li>
-          <li
-                    className="item-added-to-seat"
-          >
-                    Mahi Mahi
-                    <button
-                              className="edit-order-item-button"
-                    >
-                              Edit
-                    </button>
-                    <button
-                              className="remove-entree-order-item-button"
-                              onClick={[Function]}
-                    >
-                              X
-                    </button>
-          </li>
-</ul>,
+                              Mahi Mahi
+                              <button
+                                        className="edit-order-item-button"
+                              >
+                                        Edit
+                              </button>
+                              <button
+                                        className="remove-entree-order-item-button"
+                                        onClick={[Function]}
+                              >
+                                        X
+                              </button>
+                    </li>
+          </ul>
+</div>,
         <Link
           replace={false}
           to="/0000/tables/22"
@@ -230,7 +238,9 @@ ShallowWrapper {
         "nodeType": "host",
         "props": Object {
           "children": Array [
-            "Entrees",
+            <h3>
+              Entrees
+</h3>,
             <div
               className="entrees-list"
 >
@@ -294,7 +304,17 @@ ShallowWrapper {
         },
         "ref": null,
         "rendered": Array [
-          "Entrees",
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": "Entrees",
+            },
+            "ref": null,
+            "rendered": "Entrees",
+            "type": "h3",
+          },
           Object {
             "instance": null,
             "key": undefined,
@@ -488,9 +508,78 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "host",
         "props": Object {
-          "children": Array [
-            "Current Order:",
-            Array [
+          "children": "Current Order: ",
+        },
+        "ref": null,
+        "rendered": "Current Order: ",
+        "type": "h3",
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": <ul
+            className="current-order"
+>
+            <li
+                        className="item-added-to-seat"
+            >
+                        Lamb
+                        <button
+                                    className="edit-order-item-button"
+                        >
+                                    Edit
+                        </button>
+                        <button
+                                    className="remove-entree-order-item-button"
+                                    onClick={[Function]}
+                        >
+                                    X
+                        </button>
+            </li>
+            <li
+                        className="item-added-to-seat"
+            >
+                        Burger
+                        <button
+                                    className="edit-order-item-button"
+                        >
+                                    Edit
+                        </button>
+                        <button
+                                    className="remove-entree-order-item-button"
+                                    onClick={[Function]}
+                        >
+                                    X
+                        </button>
+            </li>
+            <li
+                        className="item-added-to-seat"
+            >
+                        Mahi Mahi
+                        <button
+                                    className="edit-order-item-button"
+                        >
+                                    Edit
+                        </button>
+                        <button
+                                    className="remove-entree-order-item-button"
+                                    onClick={[Function]}
+                        >
+                                    X
+                        </button>
+            </li>
+</ul>,
+          "className": "current-order-wrapper",
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
               <li
                 className="item-added-to-seat"
 >
@@ -540,170 +629,170 @@ ShallowWrapper {
                 </button>
 </li>,
             ],
-          ],
-          "className": "current-order",
-        },
-        "ref": null,
-        "rendered": Array [
-          "Current Order:",
-          Object {
-            "instance": null,
-            "key": "1482363367071",
-            "nodeType": "host",
-            "props": Object {
-              "children": Array [
+            "className": "current-order",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": "1482363367071",
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  "Lamb",
+                  <button
+                    className="edit-order-item-button"
+>
+                    Edit
+</button>,
+                  <button
+                    className="remove-entree-order-item-button"
+                    onClick={[Function]}
+>
+                    X
+</button>,
+                ],
+                "className": "item-added-to-seat",
+              },
+              "ref": null,
+              "rendered": Array [
                 "Lamb",
-                <button
-                  className="edit-order-item-button"
->
-                  Edit
-</button>,
-                <button
-                  className="remove-entree-order-item-button"
-                  onClick={[Function]}
->
-                  X
-</button>,
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": "Edit",
+                    "className": "edit-order-item-button",
+                  },
+                  "ref": null,
+                  "rendered": "Edit",
+                  "type": "button",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": "X",
+                    "className": "remove-entree-order-item-button",
+                    "onClick": [Function],
+                  },
+                  "ref": null,
+                  "rendered": "X",
+                  "type": "button",
+                },
               ],
-              "className": "item-added-to-seat",
+              "type": "li",
             },
-            "ref": null,
-            "rendered": Array [
-              "Lamb",
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": "Edit",
-                  "className": "edit-order-item-button",
-                },
-                "ref": null,
-                "rendered": "Edit",
-                "type": "button",
+            Object {
+              "instance": null,
+              "key": "1482363367072",
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  "Burger",
+                  <button
+                    className="edit-order-item-button"
+>
+                    Edit
+</button>,
+                  <button
+                    className="remove-entree-order-item-button"
+                    onClick={[Function]}
+>
+                    X
+</button>,
+                ],
+                "className": "item-added-to-seat",
               },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": "X",
-                  "className": "remove-entree-order-item-button",
-                  "onClick": [Function],
-                },
-                "ref": null,
-                "rendered": "X",
-                "type": "button",
-              },
-            ],
-            "type": "li",
-          },
-          Object {
-            "instance": null,
-            "key": "1482363367072",
-            "nodeType": "host",
-            "props": Object {
-              "children": Array [
+              "ref": null,
+              "rendered": Array [
                 "Burger",
-                <button
-                  className="edit-order-item-button"
->
-                  Edit
-</button>,
-                <button
-                  className="remove-entree-order-item-button"
-                  onClick={[Function]}
->
-                  X
-</button>,
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": "Edit",
+                    "className": "edit-order-item-button",
+                  },
+                  "ref": null,
+                  "rendered": "Edit",
+                  "type": "button",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": "X",
+                    "className": "remove-entree-order-item-button",
+                    "onClick": [Function],
+                  },
+                  "ref": null,
+                  "rendered": "X",
+                  "type": "button",
+                },
               ],
-              "className": "item-added-to-seat",
+              "type": "li",
             },
-            "ref": null,
-            "rendered": Array [
-              "Burger",
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": "Edit",
-                  "className": "edit-order-item-button",
-                },
-                "ref": null,
-                "rendered": "Edit",
-                "type": "button",
+            Object {
+              "instance": null,
+              "key": "1482363367073",
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  "Mahi Mahi",
+                  <button
+                    className="edit-order-item-button"
+>
+                    Edit
+</button>,
+                  <button
+                    className="remove-entree-order-item-button"
+                    onClick={[Function]}
+>
+                    X
+</button>,
+                ],
+                "className": "item-added-to-seat",
               },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": "X",
-                  "className": "remove-entree-order-item-button",
-                  "onClick": [Function],
-                },
-                "ref": null,
-                "rendered": "X",
-                "type": "button",
-              },
-            ],
-            "type": "li",
-          },
-          Object {
-            "instance": null,
-            "key": "1482363367073",
-            "nodeType": "host",
-            "props": Object {
-              "children": Array [
+              "ref": null,
+              "rendered": Array [
                 "Mahi Mahi",
-                <button
-                  className="edit-order-item-button"
->
-                  Edit
-</button>,
-                <button
-                  className="remove-entree-order-item-button"
-                  onClick={[Function]}
->
-                  X
-</button>,
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": "Edit",
+                    "className": "edit-order-item-button",
+                  },
+                  "ref": null,
+                  "rendered": "Edit",
+                  "type": "button",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": "X",
+                    "className": "remove-entree-order-item-button",
+                    "onClick": [Function],
+                  },
+                  "ref": null,
+                  "rendered": "X",
+                  "type": "button",
+                },
               ],
-              "className": "item-added-to-seat",
+              "type": "li",
             },
-            "ref": null,
-            "rendered": Array [
-              "Mahi Mahi",
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": "Edit",
-                  "className": "edit-order-item-button",
-                },
-                "ref": null,
-                "rendered": "Edit",
-                "type": "button",
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": "X",
-                  "className": "remove-entree-order-item-button",
-                  "onClick": [Function],
-                },
-                "ref": null,
-                "rendered": "X",
-                "type": "button",
-              },
-            ],
-            "type": "li",
-          },
-        ],
-        "type": "ul",
+          ],
+          "type": "ul",
+        },
+        "type": "div",
       },
       Object {
         "instance": null,
@@ -748,7 +837,9 @@ ShallowWrapper {
           <div
             className="entrees-wrapper"
 >
-            Entrees
+            <h3>
+                        Entrees
+            </h3>
             <div
                         className="entrees-list"
             >
@@ -808,59 +899,65 @@ ShallowWrapper {
                         </div>
             </div>
 </div>,
-          <ul
-            className="current-order"
+          <h3>
+            Current Order: 
+</h3>,
+          <div
+            className="current-order-wrapper"
 >
-            Current Order:
-            <li
-                        className="item-added-to-seat"
+            <ul
+                        className="current-order"
             >
-                        Lamb
-                        <button
-                                    className="edit-order-item-button"
+                        <li
+                                    className="item-added-to-seat"
                         >
-                                    Edit
-                        </button>
-                        <button
-                                    className="remove-entree-order-item-button"
-                                    onClick={[Function]}
+                                    Lamb
+                                    <button
+                                                className="edit-order-item-button"
+                                    >
+                                                Edit
+                                    </button>
+                                    <button
+                                                className="remove-entree-order-item-button"
+                                                onClick={[Function]}
+                                    >
+                                                X
+                                    </button>
+                        </li>
+                        <li
+                                    className="item-added-to-seat"
                         >
-                                    X
-                        </button>
-            </li>
-            <li
-                        className="item-added-to-seat"
-            >
-                        Burger
-                        <button
-                                    className="edit-order-item-button"
+                                    Burger
+                                    <button
+                                                className="edit-order-item-button"
+                                    >
+                                                Edit
+                                    </button>
+                                    <button
+                                                className="remove-entree-order-item-button"
+                                                onClick={[Function]}
+                                    >
+                                                X
+                                    </button>
+                        </li>
+                        <li
+                                    className="item-added-to-seat"
                         >
-                                    Edit
-                        </button>
-                        <button
-                                    className="remove-entree-order-item-button"
-                                    onClick={[Function]}
-                        >
-                                    X
-                        </button>
-            </li>
-            <li
-                        className="item-added-to-seat"
-            >
-                        Mahi Mahi
-                        <button
-                                    className="edit-order-item-button"
-                        >
-                                    Edit
-                        </button>
-                        <button
-                                    className="remove-entree-order-item-button"
-                                    onClick={[Function]}
-                        >
-                                    X
-                        </button>
-            </li>
-</ul>,
+                                    Mahi Mahi
+                                    <button
+                                                className="edit-order-item-button"
+                                    >
+                                                Edit
+                                    </button>
+                                    <button
+                                                className="remove-entree-order-item-button"
+                                                onClick={[Function]}
+                                    >
+                                                X
+                                    </button>
+                        </li>
+            </ul>
+</div>,
           <Link
             replace={false}
             to="/0000/tables/22"
@@ -883,7 +980,9 @@ ShallowWrapper {
           "nodeType": "host",
           "props": Object {
             "children": Array [
-              "Entrees",
+              <h3>
+                Entrees
+</h3>,
               <div
                 className="entrees-list"
 >
@@ -947,7 +1046,17 @@ ShallowWrapper {
           },
           "ref": null,
           "rendered": Array [
-            "Entrees",
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "Entrees",
+              },
+              "ref": null,
+              "rendered": "Entrees",
+              "type": "h3",
+            },
             Object {
               "instance": null,
               "key": undefined,
@@ -1141,9 +1250,78 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "host",
           "props": Object {
-            "children": Array [
-              "Current Order:",
-              Array [
+            "children": "Current Order: ",
+          },
+          "ref": null,
+          "rendered": "Current Order: ",
+          "type": "h3",
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": <ul
+              className="current-order"
+>
+              <li
+                            className="item-added-to-seat"
+              >
+                            Lamb
+                            <button
+                                          className="edit-order-item-button"
+                            >
+                                          Edit
+                            </button>
+                            <button
+                                          className="remove-entree-order-item-button"
+                                          onClick={[Function]}
+                            >
+                                          X
+                            </button>
+              </li>
+              <li
+                            className="item-added-to-seat"
+              >
+                            Burger
+                            <button
+                                          className="edit-order-item-button"
+                            >
+                                          Edit
+                            </button>
+                            <button
+                                          className="remove-entree-order-item-button"
+                                          onClick={[Function]}
+                            >
+                                          X
+                            </button>
+              </li>
+              <li
+                            className="item-added-to-seat"
+              >
+                            Mahi Mahi
+                            <button
+                                          className="edit-order-item-button"
+                            >
+                                          Edit
+                            </button>
+                            <button
+                                          className="remove-entree-order-item-button"
+                                          onClick={[Function]}
+                            >
+                                          X
+                            </button>
+              </li>
+</ul>,
+            "className": "current-order-wrapper",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
                 <li
                   className="item-added-to-seat"
 >
@@ -1193,170 +1371,170 @@ ShallowWrapper {
                   </button>
 </li>,
               ],
-            ],
-            "className": "current-order",
-          },
-          "ref": null,
-          "rendered": Array [
-            "Current Order:",
-            Object {
-              "instance": null,
-              "key": "1482363367071",
-              "nodeType": "host",
-              "props": Object {
-                "children": Array [
+              "className": "current-order",
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": "1482363367071",
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
+                    "Lamb",
+                    <button
+                      className="edit-order-item-button"
+>
+                      Edit
+</button>,
+                    <button
+                      className="remove-entree-order-item-button"
+                      onClick={[Function]}
+>
+                      X
+</button>,
+                  ],
+                  "className": "item-added-to-seat",
+                },
+                "ref": null,
+                "rendered": Array [
                   "Lamb",
-                  <button
-                    className="edit-order-item-button"
->
-                    Edit
-</button>,
-                  <button
-                    className="remove-entree-order-item-button"
-                    onClick={[Function]}
->
-                    X
-</button>,
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": "Edit",
+                      "className": "edit-order-item-button",
+                    },
+                    "ref": null,
+                    "rendered": "Edit",
+                    "type": "button",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": "X",
+                      "className": "remove-entree-order-item-button",
+                      "onClick": [Function],
+                    },
+                    "ref": null,
+                    "rendered": "X",
+                    "type": "button",
+                  },
                 ],
-                "className": "item-added-to-seat",
+                "type": "li",
               },
-              "ref": null,
-              "rendered": Array [
-                "Lamb",
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": "Edit",
-                    "className": "edit-order-item-button",
-                  },
-                  "ref": null,
-                  "rendered": "Edit",
-                  "type": "button",
+              Object {
+                "instance": null,
+                "key": "1482363367072",
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
+                    "Burger",
+                    <button
+                      className="edit-order-item-button"
+>
+                      Edit
+</button>,
+                    <button
+                      className="remove-entree-order-item-button"
+                      onClick={[Function]}
+>
+                      X
+</button>,
+                  ],
+                  "className": "item-added-to-seat",
                 },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": "X",
-                    "className": "remove-entree-order-item-button",
-                    "onClick": [Function],
-                  },
-                  "ref": null,
-                  "rendered": "X",
-                  "type": "button",
-                },
-              ],
-              "type": "li",
-            },
-            Object {
-              "instance": null,
-              "key": "1482363367072",
-              "nodeType": "host",
-              "props": Object {
-                "children": Array [
+                "ref": null,
+                "rendered": Array [
                   "Burger",
-                  <button
-                    className="edit-order-item-button"
->
-                    Edit
-</button>,
-                  <button
-                    className="remove-entree-order-item-button"
-                    onClick={[Function]}
->
-                    X
-</button>,
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": "Edit",
+                      "className": "edit-order-item-button",
+                    },
+                    "ref": null,
+                    "rendered": "Edit",
+                    "type": "button",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": "X",
+                      "className": "remove-entree-order-item-button",
+                      "onClick": [Function],
+                    },
+                    "ref": null,
+                    "rendered": "X",
+                    "type": "button",
+                  },
                 ],
-                "className": "item-added-to-seat",
+                "type": "li",
               },
-              "ref": null,
-              "rendered": Array [
-                "Burger",
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": "Edit",
-                    "className": "edit-order-item-button",
-                  },
-                  "ref": null,
-                  "rendered": "Edit",
-                  "type": "button",
+              Object {
+                "instance": null,
+                "key": "1482363367073",
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
+                    "Mahi Mahi",
+                    <button
+                      className="edit-order-item-button"
+>
+                      Edit
+</button>,
+                    <button
+                      className="remove-entree-order-item-button"
+                      onClick={[Function]}
+>
+                      X
+</button>,
+                  ],
+                  "className": "item-added-to-seat",
                 },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": "X",
-                    "className": "remove-entree-order-item-button",
-                    "onClick": [Function],
-                  },
-                  "ref": null,
-                  "rendered": "X",
-                  "type": "button",
-                },
-              ],
-              "type": "li",
-            },
-            Object {
-              "instance": null,
-              "key": "1482363367073",
-              "nodeType": "host",
-              "props": Object {
-                "children": Array [
+                "ref": null,
+                "rendered": Array [
                   "Mahi Mahi",
-                  <button
-                    className="edit-order-item-button"
->
-                    Edit
-</button>,
-                  <button
-                    className="remove-entree-order-item-button"
-                    onClick={[Function]}
->
-                    X
-</button>,
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": "Edit",
+                      "className": "edit-order-item-button",
+                    },
+                    "ref": null,
+                    "rendered": "Edit",
+                    "type": "button",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": "X",
+                      "className": "remove-entree-order-item-button",
+                      "onClick": [Function],
+                    },
+                    "ref": null,
+                    "rendered": "X",
+                    "type": "button",
+                  },
                 ],
-                "className": "item-added-to-seat",
+                "type": "li",
               },
-              "ref": null,
-              "rendered": Array [
-                "Mahi Mahi",
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": "Edit",
-                    "className": "edit-order-item-button",
-                  },
-                  "ref": null,
-                  "rendered": "Edit",
-                  "type": "button",
-                },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": "X",
-                    "className": "remove-entree-order-item-button",
-                    "onClick": [Function],
-                  },
-                  "ref": null,
-                  "rendered": "X",
-                  "type": "button",
-                },
-              ],
-              "type": "li",
-            },
-          ],
-          "type": "ul",
+            ],
+            "type": "ul",
+          },
+          "type": "div",
         },
         Object {
           "instance": null,

--- a/src/Components/KitchenView/KitchenView.css
+++ b/src/Components/KitchenView/KitchenView.css
@@ -2,8 +2,62 @@
   border: none;
   font-size: 12px;
   margin: 5px 0 5px 0;
-  width: 85px;
+  width: 90px;
   height: 30px;
   border-radius: 15px;
   background-color: #EFEFF0;
   color: #6D576A; }
+
+.kitchen-view-order {
+  background-color: #33202A;
+  position: relative;
+  width: 60%;
+  margin: 10px auto 10px auto;
+  border-radius: 15px;
+  padding: 5px; }
+
+.remove-from-kitchen-view {
+  border: none;
+  font-size: 12px;
+  margin: 5px 0 5px 0;
+  width: 90px;
+  height: 30px;
+  border-radius: 15px;
+  background-color: #EFEFF0;
+  color: #6D576A;
+  position: absolute;
+  top: 5px;
+  right: 5px; }
+
+.orders-wrapper {
+  height: 80%; }
+
+.all-orders {
+  height: 87%;
+  overflow-y: scroll; }
+
+.order-table-info {
+  position: absolute;
+  top: 5px;
+  left: 5px; }
+
+.seat-order-card {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  margin-top: 45px; }
+
+.seat-order {
+  background-color: #EFEFF0;
+  color: #33202A;
+  border-radius: 10px;
+  margin: 5px;
+  padding: 5px;
+  width: 45%;
+  font-weight: bolder; }
+
+.seat-order-item {
+  color: #33202A;
+  margin-top: 3px;
+  font-weight: normal; }

--- a/src/Components/KitchenView/KitchenView.css
+++ b/src/Components/KitchenView/KitchenView.css
@@ -1,0 +1,9 @@
+.table-manager-button {
+  border: none;
+  font-size: 12px;
+  margin: 5px 0 5px 0;
+  width: 85px;
+  height: 30px;
+  border-radius: 15px;
+  background-color: #EFEFF0;
+  color: #6D576A; }

--- a/src/Components/KitchenView/KitchenView.js
+++ b/src/Components/KitchenView/KitchenView.js
@@ -32,19 +32,23 @@ class KitchenView extends Component {
       return (
         <div key={index+Date.now()}
         className='kitchen-view-order'>
-          <h3>Server: {order.server}</h3>
-          <h3>Table: {order.tableNumber}</h3>
-          <button className='remove-from-kitchen-view'
+          <div className='order-table-info'>
+            <h3 className='server'>Server: {order.server}</h3>
+            <h3 className='table-number'>Table: {order.tableNumber}</h3>
+          </div>
+            <button className='remove-from-kitchen-view'
             onClick={() =>
               this.removeOrderFromQueue(order)}>Order Complete</button>
-          {this.mapSeats(order)}
+          <div className='seat-order-card'>
+            {this.mapSeats(order)}
+          </div>
         </div>
       );
     });
     return (
       <div className='orders-wrapper'>
         <Link to={`/${this.props.currentUser.loginCode}/tables`}>
-          <button>Table Manager</button>
+          <button className='table-manager-button'>Table Manager</button>
         </Link>
         <h2>All Orders</h2>
         <div className='all-orders'>

--- a/src/Components/KitchenView/KitchenView.scss
+++ b/src/Components/KitchenView/KitchenView.scss
@@ -1,0 +1,72 @@
+.table-manager-button {
+  border: none;
+  font-size: 12px;
+  margin: 5px 0 5px 0;
+  width: 90px;
+  height: 30px;
+  border-radius: 15px;
+  background-color: #EFEFF0;
+  color: #6D576A;
+}
+
+.kitchen-view-order {
+  background-color: #33202A;
+  position: relative;
+  width: 60%;
+  margin: 10px auto 10px auto;
+  border-radius: 15px;
+  padding: 5px;
+}
+
+.remove-from-kitchen-view {
+  border: none;
+  font-size: 12px;
+  margin: 5px 0 5px 0;
+  width: 90px;
+  height: 30px;
+  border-radius: 15px;
+  background-color: #EFEFF0;
+  color: #6D576A;
+  position: absolute;
+  top: 5px;
+  right: 5px;
+}
+
+.orders-wrapper {
+   height: 80%;
+}
+
+.all-orders {
+  height: 87%;
+  overflow-y: scroll;
+}
+
+.order-table-info {
+  position: absolute;
+  top: 5px;
+  left: 5px;
+}
+
+.seat-order-card {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  margin-top: 45px;
+}
+
+.seat-order {
+  background-color: #EFEFF0;
+  color: #33202A;
+  border-radius: 10px;
+  margin: 5px;
+  padding: 5px;
+  width: 45%;
+  font-weight: bolder;
+}
+
+.seat-order-item {
+  color: #33202A;
+  margin-top: 3px;
+  font-weight: normal;
+}

--- a/src/Components/KitchenView/__snapshots__/KitchenView.test.js.snap
+++ b/src/Components/KitchenView/__snapshots__/KitchenView.test.js.snap
@@ -30,7 +30,9 @@ ShallowWrapper {
           replace={false}
           to="/0000/tables"
 >
-          <button>
+          <button
+                    className="table-manager-button"
+          >
                     Table Manager
           </button>
 </Link>,
@@ -52,7 +54,9 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "class",
         "props": Object {
-          "children": <button>
+          "children": <button
+            className="table-manager-button"
+>
             Table Manager
 </button>,
           "replace": false,
@@ -65,6 +69,7 @@ ShallowWrapper {
           "nodeType": "host",
           "props": Object {
             "children": "Table Manager",
+            "className": "table-manager-button",
           },
           "ref": null,
           "rendered": "Table Manager",
@@ -109,7 +114,9 @@ ShallowWrapper {
             replace={false}
             to="/0000/tables"
 >
-            <button>
+            <button
+                        className="table-manager-button"
+            >
                         Table Manager
             </button>
 </Link>,
@@ -131,7 +138,9 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "class",
           "props": Object {
-            "children": <button>
+            "children": <button
+              className="table-manager-button"
+>
               Table Manager
 </button>,
             "replace": false,
@@ -144,6 +153,7 @@ ShallowWrapper {
             "nodeType": "host",
             "props": Object {
               "children": "Table Manager",
+              "className": "table-manager-button",
             },
             "ref": null,
             "rendered": "Table Manager",

--- a/src/Components/Seat/Seat.css
+++ b/src/Components/Seat/Seat.css
@@ -11,8 +11,7 @@
 
 .menu-item {
   color: #33202A;
-  margin-bottom: 5px;
-  text-align: left; }
+  margin-bottom: 5px; }
 
 .edit-order-item-button {
   display: none; }
@@ -20,7 +19,6 @@
 .remove-order-item-button {
   background-color: #DADADB;
   color: #A63D40;
-  float: left;
   border-radius: 50%;
   border: 1px solid #C68385;
   width: 17px;

--- a/src/Components/Seat/Seat.js
+++ b/src/Components/Seat/Seat.js
@@ -28,7 +28,7 @@ class Seat extends Component {
         className='prev-ordered-menu-item'>{item.item}
         </li>
       );
-    })
+    });
     return mappedPrevOrders;
   }
 
@@ -50,6 +50,25 @@ class Seat extends Component {
     }
   }
 
+  hasCurrentOrder() {
+    const currentSeat = this.props.currentTableOrder.find( seat => seat.seatNumber === this.props.seat.seatNumber);
+    if (currentSeat) {
+      return currentSeat.currentSeatOrder.length > 0 ?
+        'has-current-order' :
+        '';
+    } else {
+      return '';
+    }
+  }
+
+  hasPreviousOrders() {
+    const currentTable = this.props.tables.find( table => table.tableNumber === this.props.currentTableNumber);
+    const currentSeat = currentTable.seats.find( seat => seat.seatNumber === this.props.seat.seatNumber);
+    return currentSeat.order.length <= 0 ?
+      'has-no-previous-orders' :
+      '';
+  }
+
   render() {
     return (
       <div className='seat'
@@ -57,8 +76,12 @@ class Seat extends Component {
         <Link to={`/${this.props.currentUser.loginCode}/tables/${this.props.currentTable.tableNumber}/${this.props.seat.seatNumber}/menu`}>
           <h3>{this.props.seat.seatNumber}</h3>
         </Link>
-        <ul className='previous-seat-order-container'>{this.getPreviousOrders()}</ul>
-        <ul className='seat-order-container'>{this.getCurrentOrder()}</ul>
+        <div className='orders-container'>
+          <ul className='seat-order-container'>{this.getCurrentOrder()}</ul>
+          <ul className='previous-seat-order-container'>
+            <h4 className={`prev-orders-list ${this.hasPreviousOrders()} ${this.hasCurrentOrder()}`}>Previous Orders:</h4>
+            {this.getPreviousOrders()}</ul>
+        </div>
       </div>
     );
   }

--- a/src/Components/Seat/Seat.js
+++ b/src/Components/Seat/Seat.js
@@ -77,7 +77,9 @@ class Seat extends Component {
           <h3>{this.props.seat.seatNumber}</h3>
         </Link>
         <div className='orders-container'>
-          <ul className='seat-order-container'>{this.getCurrentOrder()}</ul>
+          <ul className='seat-order-container'>
+            <h4 className={`current-order-list-${this.hasCurrentOrder()}`}>Current Order:</h4>
+            {this.getCurrentOrder()}</ul>
           <ul className='previous-seat-order-container'>
             <h4 className={`prev-orders-list ${this.hasPreviousOrders()} ${this.hasCurrentOrder()}`}>Previous Orders:</h4>
             {this.getPreviousOrders()}</ul>

--- a/src/Components/Seat/Seat.js
+++ b/src/Components/Seat/Seat.js
@@ -19,6 +19,19 @@ class Seat extends Component {
     this.props.removeFromCurrentTableOrder(item, this.props.seat.seatNumber);
   }
 
+  getPreviousOrders() {
+    const currentTable = this.props.tables.find( table => table.tableNumber === this.props.currentTableNumber);
+    const currentSeat = currentTable.seats.find( seat => seat.seatNumber === this.props.seat.seatNumber);
+    const mappedPrevOrders = currentSeat.order.map( (item, index) => {
+      return (
+        <li key={index + Date.now()}
+        className='prev-ordered-menu-item'>{item.item}
+        </li>
+      );
+    })
+    return mappedPrevOrders;
+  }
+
   getCurrentOrder() {
     const currentSeat = this.props.currentTableOrder.filter( order => {
       return order.seatNumber === this.props.seat.seatNumber;
@@ -44,6 +57,7 @@ class Seat extends Component {
         <Link to={`/${this.props.currentUser.loginCode}/tables/${this.props.currentTable.tableNumber}/${this.props.seat.seatNumber}/menu`}>
           <h3>{this.props.seat.seatNumber}</h3>
         </Link>
+        <ul className='previous-seat-order-container'>{this.getPreviousOrders()}</ul>
         <ul className='seat-order-container'>{this.getCurrentOrder()}</ul>
       </div>
     );
@@ -58,7 +72,8 @@ Seat.propTypes = {
   currentTable: PropTypes.object,
   removeFromCurrentTableOrder: PropTypes.func,
   currentTableOrder: PropTypes.array,
-  currentSeatOrder: PropTypes.array
+  currentSeatOrder: PropTypes.array,
+  tables: PropTypes.array
 };
 
 export default Seat;

--- a/src/Components/Seat/Seat.scss
+++ b/src/Components/Seat/Seat.scss
@@ -37,7 +37,6 @@
 .remove-order-item-button {
   background-color: #DADADB;
   color: #A63D40;
-  // float: left;
   border-radius: 50%;
   border: 1px solid #C68385;
   width: 17px;

--- a/src/Components/Seat/Seat.scss
+++ b/src/Components/Seat/Seat.scss
@@ -13,7 +13,6 @@
 .menu-item {
   color: #33202A;
   margin-bottom: 5px;
-  text-align: left;
 }
 
 .edit-order-item-button {
@@ -23,7 +22,7 @@
 .remove-order-item-button {
   background-color: #DADADB;
   color: #A63D40;
-  float: left;
+  // float: left;
   border-radius: 50%;
   border: 1px solid #C68385;
   width: 17px;

--- a/src/Components/Seat/Seat.scss
+++ b/src/Components/Seat/Seat.scss
@@ -1,4 +1,4 @@
-.seat-order-container {
+.orders-container {
   height: 93%;
   width: 95%;
   overflow-y: scroll;
@@ -15,6 +15,21 @@
   margin-bottom: 5px;
 }
 
+.prev-ordered-menu-item {
+  color: #5F5F60;
+  margin-bottom: 5px;
+}
+
+.prev-orders-list {
+  color: #5F5F60;
+  margin: 5px 0 5px 0;
+  padding-top: 5px;
+}
+
+.has-current-order {
+  border-top: dashed 1px #5F5F60;
+}
+
 .edit-order-item-button {
   display: none;
 }
@@ -29,4 +44,8 @@
   height: 17px;
   font-size: 15px;
   margin: 0 5px 0 3px;
+}
+
+.has-no-previous-orders {
+  display: none;
 }

--- a/src/Components/Seat/Seat.scss
+++ b/src/Components/Seat/Seat.scss
@@ -30,6 +30,16 @@
   border-top: dashed 1px #5F5F60;
 }
 
+.current-order-list- {
+  display: none;
+}
+
+.current-order-list-has-current-order {
+  border: none;
+  color: #33202A;
+  margin: 5px 0 5px 0;
+}
+
 .edit-order-item-button {
   display: none;
 }

--- a/src/Components/SeatManager/SeatManager.css
+++ b/src/Components/SeatManager/SeatManager.css
@@ -43,7 +43,14 @@
   margin: auto;
   margin-bottom: 10px;
   margin-top: 10px;
-  font-size: 16px; }
+  font-size: 16px;
+  border: none; }
+
+.all-tables-button:disabled {
+  background-color: #AEAEAF; }
+
+.send-order-button:disabled {
+  background-color: #AEAEAF; }
 
 .add-seat {
   width: 75px;
@@ -75,8 +82,7 @@
   border-radius: 25px;
   color: #33202A;
   position: relative;
-  margin-top: 5px;
-  border: none; }
+  margin-top: 5px; }
 
 .server-dashboard-wrapper {
   height: 79%; }

--- a/src/Components/SeatManager/SeatManager.js
+++ b/src/Components/SeatManager/SeatManager.js
@@ -80,7 +80,7 @@ class SeatManager extends Component {
             </form>
             <Link to={`/${this.props.currentUser.loginCode}/tables`}>
               <button className='all-tables-button'
-                disabled={this.props.currentTableOrder.length > 0}
+                disabled={this.props.currentTableOrder.length}
               >All Tables
               </button>
             </Link>
@@ -92,7 +92,7 @@ class SeatManager extends Component {
 
             <button className='send-order-button'
               onClick={() => this.sendOrder()}
-              disabled={this.props.currentTableOrder.length <= 0}>Send Order</button>
+              disabled={!this.props.currentTableOrder.length}>Send Order</button>
             <Link to={`/${this.props.currentUser.loginCode}/tables`}>
               <button className='close-table-button'
                 onClick={() => this.closeTable()}>Close Table</button>

--- a/src/Reducers/AllOrdersReducer.js
+++ b/src/Reducers/AllOrdersReducer.js
@@ -4,8 +4,6 @@ const allOrders = (state = [], action) => {
     return [...state, action.orderInfo];
   case 'REMOVE_FROM_ALL_ORDERS':
     return state.filter(order => order.id !== action.order.id);
-  case 'CLEAR_ALL_ORDERS':
-    return [];
   default:
     return state;
   }

--- a/src/Reducers/AllOrdersReducer.js
+++ b/src/Reducers/AllOrdersReducer.js
@@ -3,7 +3,7 @@ const allOrders = (state = [], action) => {
   case 'ADD_TO_ALL_ORDERS':
     return [...state, action.orderInfo];
   case 'REMOVE_FROM_ALL_ORDERS':
-    return state.filter(order => order !== action.order);
+    return state.filter(order => order.id !== action.order.id);
   case 'CLEAR_ALL_ORDERS':
     return [];
   default:

--- a/src/Reducers/CurrentSeatOrderReducer.js
+++ b/src/Reducers/CurrentSeatOrderReducer.js
@@ -3,7 +3,7 @@ const currentSeatOrder = (state = [], action) => {
   case 'ADD_TO_CURRENT_SEAT_ORDER':
     return [...state, action.menuItem];
   case 'REMOVE_FROM_CURRENT_SEAT_ORDER':
-    return state.filter( item => item !== action.menuItem);
+    return state.filter( item => item.id !== action.menuItem.id);
   case 'CLEAR_CURRENT_SEAT_ORDER':
     return [];
   default:

--- a/src/Reducers/CurrentTableOrderReducer.js
+++ b/src/Reducers/CurrentTableOrderReducer.js
@@ -6,7 +6,7 @@ const currentTableOrder = (state = [], action) => {
     return state.map( seat => {
       if (seat.seatNumber === action.removeItemInfo.seatNumber) {
         const currentSeatOrder = seat.currentSeatOrder
-          .filter(item => item !== action.removeItemInfo.menuItem);
+          .filter(item => item.id !== action.removeItemInfo.menuItem.id);
         return Object.assign(seat, {currentSeatOrder: currentSeatOrder});
       } else {
         return seat;

--- a/src/Reducers/Reducers.test.js
+++ b/src/Reducers/Reducers.test.js
@@ -312,9 +312,7 @@ describe(`reducers tests`, () => {
       expect(currentTableOrder([{
         seatNumber: '2',
         currentSeatOrder:[
-          {item: 'Lamb', price: 29},
-          {item: 'Burger', price: 19},
-          {item:'Mahi Mahi', price: 27}]
+          {item: 'Lamb', price: 29}]
       }], removeFromCurrentTableOrderAction)).toEqual([]);
 
       const clearCurrentTableOrderAction =

--- a/src/Reducers/Reducers.test.js
+++ b/src/Reducers/Reducers.test.js
@@ -245,6 +245,21 @@ describe(`reducers tests`, () => {
         order: []
       });
 
+      const removeCurrentSeatAction = {
+        type: 'REMOVE_CURRENT_SEAT',
+        currentSeat: {
+          seatNumber: '1',
+          tableNumber: '22',
+          order: []
+        }
+      };
+
+      expect(currentSeat({
+        seatNumber: '1',
+        tableNumber: '22',
+        order: []
+      }, removeCurrentSeatAction)).toEqual({});
+
       const addOrderToCurrentSeatAction = {
         type: 'ADD_ORDER_TO_CURRENT_SEAT',
         order: [
@@ -346,6 +361,15 @@ describe(`reducers tests`, () => {
         tableNumber: '33',
         seats: {}
       });
+
+      const removeCurrentTableAction = {
+        type: 'REMOVE_CURRENT_TABLE'
+      };
+
+      expect(currentTable({
+        tableNumber: '33',
+        seats: {}
+      }, removeCurrentTableAction)).toEqual({});
 
     });
 

--- a/src/Reducers/Reducers.test.js
+++ b/src/Reducers/Reducers.test.js
@@ -162,7 +162,6 @@ describe(`reducers tests`, () => {
         }
       };
 
-      // this test fails
       expect(allOrders([{
         currentTableOrder: [
           {
@@ -206,7 +205,6 @@ describe(`reducers tests`, () => {
         }
       };
 
-      // this test fails
       expect(currentSeatOrder([{
         item: 'Lamb',
         price: 29
@@ -303,17 +301,19 @@ describe(`reducers tests`, () => {
         {
           type: 'REMOVE_FROM_CURRENT_TABLE_ORDER',
           removeItemInfo: {
-            menuItem: {item: 'Lamb', price: 29},
+            menuItem: {item: 'Lamb', price: 29, id: 5},
             seatNumber: '2'
           }
         };
 
-      // this test fails
       expect(currentTableOrder([{
         seatNumber: '2',
         currentSeatOrder:[
-          {item: 'Lamb', price: 29}]
-      }], removeFromCurrentTableOrderAction)).toEqual([]);
+          {item: 'Lamb', price: 29, id: 5}]
+      }], removeFromCurrentTableOrderAction)).toEqual([{
+        seatNumber: '2',
+        currentSeatOrder:[]
+      }]);
 
       const clearCurrentTableOrderAction =
         {

--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,7 @@
 @import url("./Components/MenuView/MenuView.scss");
 @import url("./Components/Entree/Entree.scss");
 @import url("./Components/Seat/Seat.scss");
+@import url("./Components/KitchenView/KitchenView.scss");
 * {
   margin: 0;
   padding: 0;

--- a/src/index.css
+++ b/src/index.css
@@ -32,6 +32,3 @@ input {
 
 ul {
   list-style: none; }
-
-.item-added-to-seat {
-  display: block; }

--- a/src/index.scss
+++ b/src/index.scss
@@ -6,6 +6,7 @@
 @import url('./Components/MenuView/MenuView.scss');
 @import url('./Components/Entree/Entree.scss');
 @import url('./Components/Seat/Seat.scss');
+@import url('./Components/KitchenView/KitchenView.scss');
 
 * {
   margin: 0;

--- a/src/index.scss
+++ b/src/index.scss
@@ -38,7 +38,3 @@ input {
 ul {
   list-style: none;
 }
-
-.item-added-to-seat {
-  display: block;
-}


### PR DESCRIPTION
## What's this PR do?

Persists order info on seats after sending order to kitchen.

## Where should the reviewer start?

Seat.js: line 53

## Any background context you want to provide?
Previously, when you sent the order to the kitchen, the seat was just blank. Now it shows up as a previous order.

## Screenshots (if appropriate)
<img width="790" alt="screen shot 2017-11-08 at 9 08 42 pm" src="https://user-images.githubusercontent.com/6845268/32588081-9a2bf892-c4c9-11e7-83fc-c364410ddfff.png">

<img width="788" alt="screen shot 2017-11-08 at 9 26 49 pm" src="https://user-images.githubusercontent.com/6845268/32588387-a25a2672-c4cb-11e7-9003-9d9ba457f2cc.png">


## What gif best describes this PR or how it makes you feel?
![giphy 6](https://user-images.githubusercontent.com/6845268/32588104-b54291c2-c4c9-11e7-83b2-7d86dadb5be3.gif)
